### PR TITLE
Fix boot race condition between Docker and network

### DIFF
--- a/0002-Add-an-arbitrary-delay-before-starting-Docker.patch
+++ b/0002-Add-an-arbitrary-delay-before-starting-Docker.patch
@@ -1,0 +1,30 @@
+From 114b84a8c848d0a1f4b1f2f5729e6796509728e7 Mon Sep 17 00:00:00 2001
+From: Brooks Swinnerton <bswinnerton@gmail.com>
+Date: Wed, 15 Aug 2018 18:50:04 -0400
+Subject: [PATCH] Add an arbitrary delay before starting Docker
+
+Due to issues with `network-online.target` in Clear Linux, a race
+condition will occur between the Docker service starting before the
+network is ready with a routable IP address.
+
+This commit represents a temporary fix to delay the start of the Docker
+service by five seconds, giving the network a chance to start.
+---
+ components/packaging/rpm/systemd/docker.service | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/components/packaging/rpm/systemd/docker.service b/components/packaging/rpm/systemd/docker.service
+index 6c60646b56..5d5774838f 100644
+--- a/components/packaging/rpm/systemd/docker.service
++++ b/components/packaging/rpm/systemd/docker.service
+@@ -28,6 +28,7 @@ KillMode=process
+ Restart=on-failure
+ StartLimitBurst=3
+ StartLimitInterval=60s
++ExecStartPre=/bin/sleep 5
+ 
+ [Install]
+ WantedBy=multi-user.target
+-- 
+2.18.0
+


### PR DESCRIPTION
👋 @bryteise, @fenrus75, I hope you don't mind the direct pings here. It looks like no one is watching this GitHub on repository, so no one would see a notification for this pull request. You both look like [active contributors](https://github.com/clearlinux-pkgs/docker/graphs/contributors) of this repository, and we've chatted about this problem in IRC ☺️.

In https://github.com/clearlinux/distribution/issues/157, I outlined a bug in Clear Linux's Docker package that caused containers to start before the host networking is ready with a routable IP address. 

In an effort to start a conversation around possible solutions, I've opened this pull request. I'm not convinced that this is the right solution, but there seems to be hesitation to addressing the other concerns in Clear Linux's `network-online.target`. This approach simply delays the start of the `docker.service` by five seconds. There isn't much significance of five seconds here, and I'm more than happy to make this a smaller number if others have strong feelings.

Other approaches that I've tried are changing the docker service's `Type=idle`, but to no avail.

##

I guessed around on how to contribute to the repositories in this organization, and very well may have made a mistake. My understanding is that `.patch` files are taken into consideration `swupd`'s build process. I created this file by:

1. Cloning docker/docker-ce, which I found from [this line](https://github.com/clearlinux-pkgs/docker/blob/master/docker.spec#L5)
2. Branched off of `master`
3. Made the change to `components/packaging/rpm/systemd/docker.service`
4. Authored the commit
5. Exported the patch with `git format-patch master`
6. Manually renamed the patch to `0002-Add-an-arbitrary-delay-before-starting-Docker.patch`, since it looks like one that starts with `0001-` [already exists](https://github.com/clearlinux-pkgs/docker/blob/master/0001-daemon.getSourceMount-fix-for-mount-point.patch)
7. Cloned this repository
8. Branched off `master`
9. Moved the patch into this directory
10. Created e2eb015

If I may have missed anything here, please let me know and I can certainly try to fix it.